### PR TITLE
Handle pre-existing linearize destination folder

### DIFF
--- a/src/main/scala/com/lightbend/coursegentools/Linearize.scala
+++ b/src/main/scala/com/lightbend/coursegentools/Linearize.scala
@@ -40,8 +40,8 @@ object Linearize {
       case (true, false) =>
         println(
           s"""
-             |Destination folder ${destinationFolder.getPath} exists: Either remove
-             |this folder manually or use the -fde to delete it automatically
+             |Destination folder ${destinationFolder.getPath} exists: Either remove this folder
+             |manually or use the '-f' command-line option to delete it automatically
              |""".stripMargin)
         System.exit(-1)
       case (true, true) =>

--- a/src/main/scala/com/lightbend/coursegentools/Linearize.scala
+++ b/src/main/scala/com/lightbend/coursegentools/Linearize.scala
@@ -26,13 +26,29 @@ object Linearize {
 
     import Helpers._
     import java.io.File
+    import sbt.{ IO => sbtio }
 
     val cmdOptions = LinearizeCmdLineOptParse.parse(args)
     if (cmdOptions.isEmpty) System.exit(-1)
-    val LinearizeCmdOptions(masterRepo, linearizedOutputFolder, multiJVM) = cmdOptions.get
+    val LinearizeCmdOptions(masterRepo, linearizedOutputFolder, multiJVM, forceDeleteExistingDestinationFolder) = cmdOptions.get
 
     val projectName = masterRepo.getName
     val exercises: Seq[String] = getExerciseNames(masterRepo)
+    val destinationFolder = new File(linearizedOutputFolder, projectName)
+
+    (destinationFolder.exists(), forceDeleteExistingDestinationFolder) match {
+      case (true, false) =>
+        println(
+          s"""
+             |Destination folder ${destinationFolder.getPath} exists: Either remove
+             |this folder manually or use the -fde to delete it automatically
+             |""".stripMargin)
+        System.exit(-1)
+      case (true, true) =>
+        sbtio.delete(destinationFolder)
+      case _ =>
+
+    }
 
     val tmpDir = cleanMasterViaGit(masterRepo, projectName)
     val cleanMasterRepo = new File(tmpDir, projectName)

--- a/src/main/scala/com/lightbend/coursegentools/LinearizeCmdLineOptParse.scala
+++ b/src/main/scala/com/lightbend/coursegentools/LinearizeCmdLineOptParse.scala
@@ -56,7 +56,7 @@ object LinearizeCmdLineOptParse {
 
       opt[Unit]("force-delete-existing-destination-folder")
         .text("generate multi-jvm build file")
-        .abbr("fde")
+        .abbr("f")
         .action { case (_, c) =>
           c.copy(forceDeleteExistingDestinationFolder = true)
         }

--- a/src/main/scala/com/lightbend/coursegentools/LinearizeCmdLineOptParse.scala
+++ b/src/main/scala/com/lightbend/coursegentools/LinearizeCmdLineOptParse.scala
@@ -54,6 +54,12 @@ object LinearizeCmdLineOptParse {
           c.copy(multiJVM = true)
         }
 
+      opt[Unit]("force-delete-existing-destination-folder")
+        .text("generate multi-jvm build file")
+        .abbr("fde")
+        .action { case (_, c) =>
+          c.copy(forceDeleteExistingDestinationFolder = true)
+        }
     }
 
     parser.parse(args, LinearizeCmdOptions())

--- a/src/main/scala/com/lightbend/coursegentools/package.scala
+++ b/src/main/scala/com/lightbend/coursegentools/package.scala
@@ -40,7 +40,8 @@ package object coursegentools {
 
   case class LinearizeCmdOptions(masterRepo: File = new File("."),
                                  linearRepo: File = new File("."),
-                                 multiJVM: Boolean = false)
+                                 multiJVM: Boolean = false,
+                                 forceDeleteExistingDestinationFolder: Boolean = false)
 
   case class DeLinearizeCmdOptions(masterRepo: File = new File("."),
                                    linearRepo: File = new File("."))


### PR DESCRIPTION
Fixes a bug which cause a problem if a master repo was linearized
into an already existing folder containing a linearized version
of that repo.
In this new version, this situation is detected and the linearization
is aborted.
A new command line option is provided to automatically delete an
already existing destination folder