### PR TITLE
Generalise studentify

### DIFF
--- a/checkIfWorkspaceClean.sh
+++ b/checkIfWorkspaceClean.sh
@@ -1,0 +1,13 @@
+#!/bin/ksh
+
+MASTER_REPO=$1
+cd $MASTER_REPO
+
+print "CHECKING WORKSPACE in $MASTER_REPO"
+xx=`git status --porcelain|wc -l`
+
+if [ $xx -eq 0 ];then
+  exit 0
+else
+  exit 1
+fi

--- a/sbtStudentCommands/Navigation.scala.template
+++ b/sbtStudentCommands/Navigation.scala.template
@@ -120,10 +120,10 @@ object Navigation {
         exercises match {
           case exercise +: Nil =>
             withZipFile(state, exercise) { () =>
-              val src = Project.extract(state).get(sourceDirectory)
-              val newExerciseSrc = new sbt.File(new sbt.File(Project.extract(state).structure.root), s".cue/$exercise/src")
+              val src = new sbt.File(new sbt.File(Project.extract(state).structure.root), "exercises")
+              val newExerciseSrc = new sbt.File(new sbt.File(Project.extract(state).structure.root), s".cue/$exercise")
               for {
-                f <- List("test", "multi-jvm")
+                f <- TestFolders.testFolders
                 fromFolder = new File(newExerciseSrc, f)
                 toFolder = new File(src, f)
               } {
@@ -177,11 +177,13 @@ object Navigation {
         newState
       case (true, toProjectName, _) =>
         withZipFile(state, toProjectName) { () =>
-          val src = Project.extract(state).get(sourceDirectory)
+          //val src = Project.extract(state).get(sourceDirectory)
+          val src = new sbt.File(new sbt.File(Project.extract(state).structure.root), "exercises")
+          //println(s"=== src = $src ===")
           // update tests (can be previous or next...)
-          val newExerciseSrc = new sbt.File(new sbt.File(Project.extract(state).structure.root), s".cue/$toProjectName/src")
+          val newExerciseSrc = new sbt.File(new sbt.File(Project.extract(state).structure.root), s".cue/$toProjectName")
           for {
-            f <- List("test", "multi-jvm")
+            f <- TestFolders.testFolders
             fromFolder = new File(newExerciseSrc, f)
             toFolder = new File(src, f)
           } {

--- a/sbtStudentCommands/Pssr.scala.template
+++ b/sbtStudentCommands/Pssr.scala.template
@@ -40,9 +40,9 @@ object Pssr {
   def pullSolution: Command = Command.command("pullSolution") { state =>
     val currentExercise = getCurrentExercise(state)
     withZipFile(state, currentExercise) { () =>
-      val currentExerciseMain = new sbt.File(getRootFolder(state), "exercises/src/main")
+      val currentExerciseMain = new sbt.File(getRootFolder(state), "exercises")
       val cueFolder = getCueFolder(state)
-      val solFolder = new sbt.File(cueFolder, currentExercise + "/src/main")
+      val solFolder = new sbt.File(cueFolder, currentExercise)
       IO.delete(currentExerciseMain)
       IO.copyDirectory(solFolder, currentExerciseMain)
       Console.println(Console.GREEN + "[INFO] " + Console.RESET + s"Solution for exercise $currentExercise pulled successfully")

--- a/sbtStudentCommands/Pssr.scala.template
+++ b/sbtStudentCommands/Pssr.scala.template
@@ -52,8 +52,8 @@ object Pssr {
 
   def saveState: Command = Command.command("saveState") { state =>
     val currentExercise = getCurrentExercise(state)
-    val saveFolder = new sbt.File(getSavedStateFolder(state), currentExercise + "/src")
-    val currentExerciseSrc = new sbt.File(getRootFolder(state), "exercises/src")
+    val saveFolder = new sbt.File(getSavedStateFolder(state), currentExercise)
+    val currentExerciseSrc = new sbt.File(getRootFolder(state), "exercises")
     if (saveFolder exists) IO.delete(saveFolder)
     IO.copyDirectory(currentExerciseSrc, saveFolder)
     Console.println(Console.GREEN + "[INFO] " + Console.RESET + s"State for exercise " + Console.BLUE + currentExercise + Console.RESET + " saved successfully")
@@ -65,8 +65,8 @@ object Pssr {
       case Some(exercise) =>
         val savedFolder = new sbt.File(getSavedStateFolder(state), exercise)
         if (savedFolder.exists()) {
-          val savedStateFolder = new sbt.File(savedFolder, "src")
-          val currentExerciseSrc = new sbt.File(getRootFolder(state), "exercises/src")
+          val savedStateFolder = savedFolder
+          val currentExerciseSrc = new sbt.File(getRootFolder(state), "exercises")
           IO.delete(currentExerciseSrc)
           IO.copyDirectory(savedStateFolder, currentExerciseSrc)
           bookmark(exercise, state)

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -3,4 +3,5 @@ studentify {
     solution-folder = ".cue"
     student-base-project = "exercises"
   }
+  master-configuration = course_management.conf
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -3,5 +3,5 @@ studentify {
     solution-folder = ".cue"
     student-base-project = "exercises"
   }
-  master-configuration = course_management.conf
+  student-settings-file = .student-settings.conf
 }

--- a/src/main/scala/com/lightbend/coursegentools/Helpers.scala
+++ b/src/main/scala/com/lightbend/coursegentools/Helpers.scala
@@ -246,20 +246,21 @@ object Helpers {
         "build.sbt.template"
       }
     sbtio.copyFile(new File(buildFileTemplate), new File(targetFolder, "build.sbt"))
-
-//    val templateFiles = sbtio.listFiles(new File("."), SbtTemplateFile()).filterNot(_.getName startsWith("build"))
-//    for {
-//      sbtTemplateFile <- templateFiles
-//      sbtFileName = sbtTemplateFile.getName.replaceAll(".template", "")
-//      sbtFile = new File(targetFolder, sbtFileName)
-//    } {
-//      sbtio.copyFile(sbtTemplateFile, sbtFile)
-//    }
   }
 
   def cleanUp(files: Seq[String], targetFolder: File): Unit = {
     for (file <- files) {
       sbtio.delete(new File(targetFolder, file))
     }
+  }
+
+  def exitIfGitIndexOrWorkspaceIsntClean(masterRepo: File): Unit = {
+    """git diff-index --quiet HEAD --"""
+      .toProcessCmd(workingDir = masterRepo)
+      .runAndExitIfFailed(s"YOU HAVE UNCOMMITTED CHANGES IN YOUR GIT INDEX. COMMIT CHANGES AND RE-RUN STUDENTIFY")
+
+    s"""./checkIfWorkspaceClean.sh ${masterRepo.getPath}"""
+      .toProcessCmd(workingDir = new File("."))
+      .runAndExitIfFailed(s"YOU HAVE CHANGES IN YOUR GIT WORKSPACE. COMMIT CHANGES AND RE-RUN STUDENTIFY")
   }
 }

--- a/src/main/scala/com/lightbend/coursegentools/ProcessDSL.scala
+++ b/src/main/scala/com/lightbend/coursegentools/ProcessDSL.scala
@@ -38,7 +38,7 @@ object ProcessDSL {
              |  Executed command: ${cmd.cmd.mkString(" ")}
              |  Working directory: ${cmd.workingDir}
            """.stripMargin)
-        System.exit(-1)
+        System.exit(status.getOrElse(-1))
       }
     }
   }

--- a/src/main/scala/com/lightbend/coursegentools/Settings.scala
+++ b/src/main/scala/com/lightbend/coursegentools/Settings.scala
@@ -30,6 +30,6 @@ object Settings {
 
   val studentBaseProject = config.getString("studentify.exercises.student-base-project")
 
-  val masterConfigurationFile = config.getString("studentify.master-configuration")
+  val studentSettingsFile = config.getString("studentify.student-settings-file")
 
 }

--- a/src/main/scala/com/lightbend/coursegentools/Settings.scala
+++ b/src/main/scala/com/lightbend/coursegentools/Settings.scala
@@ -30,4 +30,6 @@ object Settings {
 
   val studentBaseProject = config.getString("studentify.exercises.student-base-project")
 
+  val masterConfigurationFile = config.getString("studentify.master-configuration")
+
 }

--- a/src/main/scala/com/lightbend/coursegentools/Studentify.scala
+++ b/src/main/scala/com/lightbend/coursegentools/Studentify.scala
@@ -50,7 +50,7 @@ object Studentify {
     createEclipseBuildSettings(targetCourseFolder, List("common", "exercises"))
     addSbtStudentCommands(sbtStudentCommandsTemplateFolder, targetCourseFolder)
     loadStudentSettings(masterRepo, targetCourseFolder)
-    cleanUp(List(".git", ".gitignore", ".sbtopts", "man.sbt", "navigation.sbt", "shell-prompt.sbt"), targetCourseFolder)
+    cleanUp(List(".git", ".gitignore", "man.sbt", "navigation.sbt", "shell-prompt.sbt"), targetCourseFolder)
     sbt.IO.delete(tmpDir)
 
   }

--- a/src/main/scala/com/lightbend/coursegentools/Studentify.scala
+++ b/src/main/scala/com/lightbend/coursegentools/Studentify.scala
@@ -31,6 +31,8 @@ object Studentify {
     if (cmdOptions.isEmpty) System.exit(-1)
     val StudentifyCmdOptions(masterRepo, targetFolder, multiJVM, firstOpt, lastOpt, selectedFirstOpt) = cmdOptions.get
 
+    exitIfGitIndexOrWorkspaceIsntClean(masterRepo)
+
     val projectName = masterRepo.getName
     val tmpDir = cleanMasterViaGit(masterRepo, projectName)
     val cleanMasterRepo = new File(tmpDir, projectName)

--- a/src/main/scala/com/lightbend/coursegentools/Studentify.scala
+++ b/src/main/scala/com/lightbend/coursegentools/Studentify.scala
@@ -32,13 +32,13 @@ object Studentify {
     val StudentifyCmdOptions(masterRepo, targetFolder, multiJVM, firstOpt, lastOpt, selectedFirstOpt) = cmdOptions.get
 
     exitIfGitIndexOrWorkspaceIsntClean(masterRepo)
-
     val projectName = masterRepo.getName
+    val targetCourseFolder = new File(targetFolder, projectName)
+
     val tmpDir = cleanMasterViaGit(masterRepo, projectName)
     val cleanMasterRepo = new File(tmpDir, projectName)
     val exercises: Seq[String] = getExerciseNames(cleanMasterRepo)
     val selectedExercises: Seq[String] = getSelectedExercises(exercises, firstOpt, lastOpt)
-    val targetCourseFolder = new File(targetFolder, projectName)
     val initialExercise = getInitialExercise(selectedFirstOpt, selectedExercises)
     val sbtStudentCommandsTemplateFolder = new File("sbtStudentCommands")
     stageFirstExercise(initialExercise, cleanMasterRepo, targetCourseFolder)
@@ -49,6 +49,7 @@ object Studentify {
     createBuildFile(targetCourseFolder, multiJVM)
     createEclipseBuildSettings(targetCourseFolder, List("common", "exercises"))
     addSbtStudentCommands(sbtStudentCommandsTemplateFolder, targetCourseFolder)
+    loadStudentSettings(masterRepo, targetCourseFolder)
     cleanUp(List(".git", ".gitignore", ".sbtopts", "man.sbt", "navigation.sbt", "shell-prompt.sbt"), targetCourseFolder)
     sbt.IO.delete(tmpDir)
 


### PR DESCRIPTION
Added support for non-standard Java/Scala projects

Cherry-picked commit `edca749 Don't delete the sbt opts file` from Wade from branch `support-lagom`. Other commits in this branch were already implemented in branch `generalise-studentify`.

For a non-Java/Scala project, one needs to create a file `.student-settings.conf` in the root folder of the _course_ master repository.

Suppose that across all _exercises_ in the course, the following folders contain test code that must be pulled in by the `nextExercise`, `prevExercise` or `gotoExerciseNr` commands:

```
src/test
BiddingImpl/test
DashImpl/test
```

In order for this to work, 

the following line is added to `.student-settings.conf`:

```
TestCodeFolders=src/test:BiddingImpl/test:DashImpl/test
```