### PR TITLE
Check that git workspace is clean before linearizing a project

### DIFF
--- a/src/main/scala/com/lightbend/coursegentools/Linearize.scala
+++ b/src/main/scala/com/lightbend/coursegentools/Linearize.scala
@@ -32,6 +32,8 @@ object Linearize {
     if (cmdOptions.isEmpty) System.exit(-1)
     val LinearizeCmdOptions(masterRepo, linearizedOutputFolder, multiJVM, forceDeleteExistingDestinationFolder) = cmdOptions.get
 
+    exitIfGitIndexOrWorkspaceIsntClean(masterRepo)
+
     val projectName = masterRepo.getName
     val exercises: Seq[String] = getExerciseNames(masterRepo)
     val destinationFolder = new File(linearizedOutputFolder, projectName)


### PR DESCRIPTION
We now check that the course master project's git workspace and index
are clean. If not, an error message is printed stating that all
changes should be committed first and the command exits.