### PR TITLE
Add support for slide deck in a subfolder named 'deck'

### DIFF
--- a/createRelease.sh
+++ b/createRelease.sh
@@ -100,7 +100,11 @@ function copy_deck {
     echo $SEPARATOR
     
     cd $STARTING_DIR
-    cp -r $REPO "$WORKING_DIR/$REPO_NAME"
+    if [[ -d ${REPO}/deck ]];then
+      cp -r ${REPO}/deck "$WORKING_DIR/$REPO_NAME"
+    else
+      cp -r $REPO "$WORKING_DIR/$REPO_NAME"
+    fi
     cd $WORKING_DIR
 }
 


### PR DESCRIPTION
Current version of createRelease.sh assumes that slides are in
project root folder.
This change will instead copy 'deck' folder if such a folder exists
in the project, otherwise it will do what it used to do before.