### PR TITLE
Add master adm command and doc update

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,3 +23,4 @@ scalacOptions ++= List(
 addCommandAlias("studentify", "runMain com.lightbend.coursegentools.Studentify")
 addCommandAlias("linearize", "runMain com.lightbend.coursegentools.Linearize")
 addCommandAlias("delinearize", "runMain com.lightbend.coursegentools.DeLinearize")
+addCommandAlias("masteradm", "runMain com.lightbend.coursegentools.MasterAdm")

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -22,7 +22,12 @@ studentify {
   # Folder where solution for exercises will be stashed away (as zip archives)
   solution-folder = ".cue"
 
+  # Master project name
+  # Rename this to avoid that your IDE project history is filled with instances of "base"
+  master-base-project-name = "base"
+
   # Studentified project name
+  # Rename this to avoid that your IDE project history is filled with instances of "base"
   studentified-project-name = "base"
 
   # Console colors

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -36,4 +36,16 @@ studentify {
     prompt-course-name         = reset
     prompt-exercise-name-color = green
   }
+
+  # Files to clean-up in the studentified repo
+  studentify-files-to-clean-up = [
+    .git
+    .gitignore
+    man.sbt
+    navigation.sbt
+    shell-prompt.sbt
+    Jenkinsfile
+    Jenkinsfile.original
+    course-management.conf
+  ]
 }

--- a/src/main/scala/com/lightbend/coursegentools/Helpers.scala
+++ b/src/main/scala/com/lightbend/coursegentools/Helpers.scala
@@ -261,7 +261,7 @@ object Helpers {
 
     val buildDefinition = if (multiJVM) {
       s"""
-         |lazy val base = (project in file("."))
+         |lazy val ${config.masterBaseProjectName} = (project in file("."))
          |  .aggregate(
          |    common,
          |    $exerciseList
@@ -278,7 +278,7 @@ object Helpers {
        """.stripMargin
     } else {
       s"""
-         |lazy val base = (project in file("."))
+         |lazy val ${config.masterBaseProjectName} = (project in file("."))
          |  .aggregate(
          |    common,
          |    $exerciseList

--- a/src/main/scala/com/lightbend/coursegentools/Helpers.scala
+++ b/src/main/scala/com/lightbend/coursegentools/Helpers.scala
@@ -238,6 +238,30 @@ object Helpers {
     selExcs
   }
 
+  def duplicateExercise(masterRepo: File,
+                        exercise: String,
+                        exerciseNr: Int)(implicit config: MasterSettings): Unit = {
+
+    val relativeSourceFolder = new File(masterRepo, config.relativeSourceFolder)
+    val newExercise = renumberExercise(exercise, exerciseNr) + "_copy"
+    sbtio.copyDirectory(new File(relativeSourceFolder, exercise), new File(relativeSourceFolder, newExercise), preserveLastModified = true)
+  }
+
+  def shiftExercisesUp(masterRepo: File,
+                       exercises: Vector[String],
+                       startFromExerciseNumber: Int,
+                       exerciseNumbers: Vector[Int])(implicit config: MasterSettings): Unit = {
+
+    val relativeSourceFolder = new File(masterRepo, config.relativeSourceFolder)
+    val exercisesToShift = exercises.dropWhile(exercise => extractExerciseNr(exercise) != startFromExerciseNumber)
+    val moves = for {
+      exercise <- exercisesToShift
+      oldExDir = new File(relativeSourceFolder, exercise)
+      newExDir = new File(relativeSourceFolder, renumberExercise(exercise, extractExerciseNr(exercise) + 1))
+    } yield (oldExDir, newExDir)
+    sbtio.move(moves)
+  }
+
   def createMasterBuildFile(exercises: Seq[String],
                             masterRepo: File,
                             multiJVM: Boolean)(implicit config: MasterSettings): Unit = {

--- a/src/main/scala/com/lightbend/coursegentools/MasterAdm.scala
+++ b/src/main/scala/com/lightbend/coursegentools/MasterAdm.scala
@@ -1,29 +1,74 @@
 package com.lightbend.coursegentools
 
-import com.lightbend.coursegentools.Helpers.getExerciseNames
+import java.io.File
 
 object MasterAdm {
 
   def main(args: Array[String]): Unit = {
     import Helpers._
-    import java.io.File
-    import sbt.io.{IO => sbtio}
 
     val cmdOptions = MasterAdmCmdLineOptParse.parse(args)
     if (cmdOptions.isEmpty) System.exit(-1)
-    val MasterAdmCmdOptions(masterRepo, multiJVM, regenBuildFile, configurationFile) = cmdOptions.get
+    val MasterAdmCmdOptions(masterRepo,
+                            multiJVM,
+                            regenBuildFile,
+                            duplicateInsertBefore,
+                            deleteExerciseNr,
+                            renumberExercises,
+                            renumberExercisesBase,
+                            renumberExercisesStep,
+                            configurationFile) = cmdOptions.get
 
     implicit val config: MasterSettings = new MasterSettings(masterRepo, configurationFile)
 
-    val exercises: Seq[String] = getExerciseNames(masterRepo)
-    val ExerciseNumberSpec = """exercise_(\d{3})_.*""".r
-    val exerciseNumbers = exercises.map{ s => val ExerciseNumberSpec(d) = s; d.toInt }
+    val exercises: Vector[String] = getExerciseNames(masterRepo)
+    val exerciseNumbers = exercises.map(extractExerciseNr)
 
-    (regenBuildFile) match {
-      case true =>
+    (regenBuildFile, duplicateInsertBefore, deleteExerciseNr, renumberExercises, renumberExercisesBase, renumberExercisesStep) match {
+      case (true, None, None, false, _, _) =>
         createMasterBuildFile(exercises, masterRepo, multiJVM)
 
-      case _ => println(s"Nothing to do...")
+      case (false, Some(dibExNr), None, false, _, _) if exerciseNumbers.contains(dibExNr) =>
+        val exercise = getExerciseName(exercises, dibExNr).get
+        if (exerciseNumbers.contains(dibExNr - 1)) {
+          duplicateExercise(masterRepo, exercise, dibExNr)
+          shiftExercisesUp(masterRepo, exercises, dibExNr, exerciseNumbers)
+        } else {
+          duplicateExercise(masterRepo, exercise, dibExNr - 1)
+        }
+        createMasterBuildFile(getExerciseNames(masterRepo), masterRepo, multiJVM)
+
+      case (false, Some(dibExNr), None, false, _, _) =>
+        println(toConsoleRed(s"Duplicate and insert before: no exercise with number $dibExNr"))
+        System.exit(-1)
+
+      case (false, None, Some(dibExNr), false, _, _) if exerciseNumbers.contains(dibExNr) =>
+        import sbt.io.{IO => sbtio}
+        val relativeSourceFolder = new File(masterRepo, config.relativeSourceFolder)
+        val exercise = getExerciseName(exercises, dibExNr).get
+        sbtio.delete(new File(relativeSourceFolder, exercise))
+        createMasterBuildFile(getExerciseNames(masterRepo), masterRepo, multiJVM)
+
+      case (false, None, Some(dibExNr), false, _, _) =>
+        println(toConsoleRed(s"Delete exercise: no exercise with number $dibExNr"))
+        System.exit(-1)
+
+      case (false, None, None, true, offset, step) =>
+        import sbt.io.{IO => sbtio}
+        val relativeSourceFolder = new File(masterRepo, config.relativeSourceFolder)
+        val moves = for {
+          (exercise, index) <- exercises.zipWithIndex
+          newIndex = offset + index * step
+          oldExDir = new File(relativeSourceFolder, exercise)
+          newExDir = new File(relativeSourceFolder, renumberExercise(exercise, newIndex))
+            if oldExDir != newExDir
+        } yield (oldExDir, newExDir)
+        sbtio.move(moves)
+        createMasterBuildFile(getExerciseNames(masterRepo), masterRepo, multiJVM)
+
+      case (false, None, None, false, _, _) => println(toConsoleGreen(s"Nothing to do..."))
+
+      case _ => println(toConsoleRed(s"Invalid combination of options"))
 
     }
 

--- a/src/main/scala/com/lightbend/coursegentools/MasterAdm.scala
+++ b/src/main/scala/com/lightbend/coursegentools/MasterAdm.scala
@@ -23,7 +23,6 @@ object MasterAdm {
       case true =>
         createMasterBuildFile(exercises, masterRepo, multiJVM)
 
-
       case _ => println(s"Nothing to do...")
 
     }

--- a/src/main/scala/com/lightbend/coursegentools/MasterAdm.scala
+++ b/src/main/scala/com/lightbend/coursegentools/MasterAdm.scala
@@ -24,13 +24,22 @@ object MasterAdm {
     val exercises: Vector[String] = getExerciseNames(masterRepo)
     val exerciseNumbers = exercises.map(extractExerciseNr)
 
-    (regenBuildFile, duplicateInsertBefore, deleteExerciseNr, renumberExercises, renumberExercisesBase, renumberExercisesStep) match {
-      case (true, None, None, false, _, _) =>
+    (regenBuildFile,
+     duplicateInsertBefore,
+     deleteExerciseNr,
+     renumberExercises, renumberExercisesBase, renumberExercisesStep) match {
+      case (true,
+            None,
+            None,
+            false, _, _) =>
         createMasterBuildFile(exercises, masterRepo, multiJVM)
 
-      case (false, Some(dibExNr), None, false, _, _) if exerciseNumbers.contains(dibExNr) =>
+      case (false,
+            Some(dibExNr),
+            None,
+            false, _, _) if exerciseNumbers.contains(dibExNr) =>
         val exercise = getExerciseName(exercises, dibExNr).get
-        if (exerciseNumbers.contains(dibExNr - 1)) {
+        if (exerciseNumbers.contains(dibExNr - 1) || dibExNr == 0) {
           duplicateExercise(masterRepo, exercise, dibExNr)
           shiftExercisesUp(masterRepo, exercises, dibExNr, exerciseNumbers)
         } else {
@@ -38,22 +47,34 @@ object MasterAdm {
         }
         createMasterBuildFile(getExerciseNames(masterRepo), masterRepo, multiJVM)
 
-      case (false, Some(dibExNr), None, false, _, _) =>
+      case (false,
+            Some(dibExNr),
+            None,
+            false, _, _) =>
         println(toConsoleRed(s"Duplicate and insert before: no exercise with number $dibExNr"))
         System.exit(-1)
 
-      case (false, None, Some(dibExNr), false, _, _) if exerciseNumbers.contains(dibExNr) =>
+      case (false,
+            None,
+            Some(dibExNr),
+            false, _, _) if exerciseNumbers.contains(dibExNr) =>
         import sbt.io.{IO => sbtio}
         val relativeSourceFolder = new File(masterRepo, config.relativeSourceFolder)
         val exercise = getExerciseName(exercises, dibExNr).get
         sbtio.delete(new File(relativeSourceFolder, exercise))
         createMasterBuildFile(getExerciseNames(masterRepo), masterRepo, multiJVM)
 
-      case (false, None, Some(dibExNr), false, _, _) =>
+      case (false,
+            None,
+            Some(dibExNr),
+            false, _, _) =>
         println(toConsoleRed(s"Delete exercise: no exercise with number $dibExNr"))
         System.exit(-1)
 
-      case (false, None, None, true, offset, step) =>
+      case (false,
+            None,
+            None,
+            true, offset, step) =>
         import sbt.io.{IO => sbtio}
         val relativeSourceFolder = new File(masterRepo, config.relativeSourceFolder)
         val moves = for {

--- a/src/main/scala/com/lightbend/coursegentools/MasterAdm.scala
+++ b/src/main/scala/com/lightbend/coursegentools/MasterAdm.scala
@@ -1,0 +1,34 @@
+package com.lightbend.coursegentools
+
+import com.lightbend.coursegentools.Helpers.getExerciseNames
+
+object MasterAdm {
+
+  def main(args: Array[String]): Unit = {
+    import Helpers._
+    import java.io.File
+    import sbt.io.{IO => sbtio}
+
+    val cmdOptions = MasterAdmCmdLineOptParse.parse(args)
+    if (cmdOptions.isEmpty) System.exit(-1)
+    val MasterAdmCmdOptions(masterRepo, multiJVM, regenBuildFile, configurationFile) = cmdOptions.get
+
+    implicit val config: MasterSettings = new MasterSettings(masterRepo, configurationFile)
+
+    val exercises: Seq[String] = getExerciseNames(masterRepo)
+    val ExerciseNumberSpec = """exercise_(\d{3})_.*""".r
+    val exerciseNumbers = exercises.map{ s => val ExerciseNumberSpec(d) = s; d.toInt }
+
+    (regenBuildFile) match {
+      case true =>
+        createMasterBuildFile(exercises, masterRepo, multiJVM)
+
+
+      case _ => println(s"Nothing to do...")
+
+    }
+
+  }
+
+
+}

--- a/src/main/scala/com/lightbend/coursegentools/MasterAdmCmdLineOptParse.scala
+++ b/src/main/scala/com/lightbend/coursegentools/MasterAdmCmdLineOptParse.scala
@@ -1,0 +1,66 @@
+package com.lightbend.coursegentools
+
+import java.io.File
+
+/**
+  * Copyright © 2016 Lightbend, Inc
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  *
+  * NO COMMERCIAL SUPPORT OR ANY OTHER FORM OF SUPPORT IS OFFERED ON
+  * THIS SOFTWARE BY LIGHTBEND, Inc.
+  *
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+object MasterAdmCmdLineOptParse {
+  def parse(args: Array[String]): Option[MasterAdmCmdOptions] = {
+
+    val parser = new scopt.OptionParser[MasterAdmCmdOptions]("masteradm") {
+      head("masteradm", "3.0")
+
+      arg[File]("masterRepo")
+        .text("base folder holding master course repository")
+        .action { case (masterRepo, c) =>
+          if (! folderExists(masterRepo)) {
+            println(toConsoleRed(s"Base master repo folder (${masterRepo.getPath}) doesn't exist"))
+            System.exit(-1)
+          }
+          c.copy(masterRepo = masterRepo)
+        }
+
+      opt[Unit]("multi-jvm")
+        .text("generate multi-jvm build file")
+        .abbr("mjvm")
+        .action { case (_, c) =>
+          c.copy(multiJVM = true)
+        }
+
+      opt[Unit]("build-file-regen")
+        .text("regenerate project root build file")
+        .abbr("b")
+        .action { case (_, c) =>
+            c.copy(regenBuildFile = true)
+        }
+
+      opt[String]("config-file")
+        .text("configuration file")
+        .abbr("cfg")
+        .action {
+          case (cfgFile, c) =>
+            c.copy(configurationFile = Some(cfgFile))
+        }
+    }
+
+    parser.parse(args, MasterAdmCmdOptions())
+  }
+}

--- a/src/main/scala/com/lightbend/coursegentools/MasterAdmCmdLineOptParse.scala
+++ b/src/main/scala/com/lightbend/coursegentools/MasterAdmCmdLineOptParse.scala
@@ -52,6 +52,41 @@ object MasterAdmCmdLineOptParse {
             c.copy(regenBuildFile = true)
         }
 
+      opt[Int]("delete")
+        .text("")
+        .abbr("d")
+        .action { case (exNr, c) =>
+          c.copy(deleteExerciseNr = Some(exNr))
+        }
+
+      opt[Unit]("renumber")
+        .text("renumber exercises")
+        .abbr("r")
+        .action { case (_, c) =>
+            c.copy(renumberExercises = true)
+        }
+
+      opt[Int]("renumber-offset")
+        .text("renumber exercises - offset")
+        .abbr("ro")
+        .action { case (offset, c) =>
+            c.copy(renumberExercisesBase = offset)
+        }
+
+      opt[Int]("renumber-step")
+        .text("renumber exercises - step")
+        .abbr("rs")
+        .action { case (step, c) =>
+          c.copy(renumberExercisesStep = step)
+        }
+
+      opt[Int]("duplicate-insert-before")
+        .text("")
+        .abbr("dib")
+        .action { case (exNr, c) =>
+          c.copy(duplicateExerciseInsertBeforeNr = Some(exNr))
+        }
+
       opt[String]("config-file")
         .text("configuration file")
         .abbr("cfg")

--- a/src/main/scala/com/lightbend/coursegentools/MasterSettings.scala
+++ b/src/main/scala/com/lightbend/coursegentools/MasterSettings.scala
@@ -66,6 +66,7 @@ class MasterSettings(masterRepo: File, optConfigurationFile: Option[String]) {
 
   val solutionsFolder: String = config.getString("studentify.solution-folder")
 
+  val masterBaseProjectName: String = config.getString("studentify.master-base-project-name")
   val studentifiedProjectName: String = config.getString("studentify.studentified-project-name")
 
   object Colors {

--- a/src/main/scala/com/lightbend/coursegentools/MasterSettings.scala
+++ b/src/main/scala/com/lightbend/coursegentools/MasterSettings.scala
@@ -57,6 +57,8 @@ class MasterSettings(masterRepo: File, optConfigurationFile: Option[String]) {
 
   val studentifyModeSelect: String = config.getString("studentify.studentify-mode-select")
 
+  val studentifyFilesToCleanUp: List[String] = config.getStringList("studentify.studentify-files-to-clean-up").asScala.toList
+
   val relativeSourceFolder: String = config.getString("studentify.relative-source-folder")
 
   object studentifyModeClassic {

--- a/src/main/scala/com/lightbend/coursegentools/MasterSettings.scala
+++ b/src/main/scala/com/lightbend/coursegentools/MasterSettings.scala
@@ -40,9 +40,7 @@ class MasterSettings(masterRepo: File, optConfigurationFile: Option[String]) {
 
   private val defaultConfigFile: Option[File] = {
     val configFile = new File(masterRepo, optConfigurationFile.getOrElse("course-management.conf"))
-    if (configFile.exists())
-      Some(configFile)
-    else None
+    if (configFile.exists()) Some(configFile) else None
   }
 
   private val config = (cmdLineConfigFile, defaultConfigFile) match {

--- a/src/main/scala/com/lightbend/coursegentools/Studentify.scala
+++ b/src/main/scala/com/lightbend/coursegentools/Studentify.scala
@@ -24,17 +24,6 @@ import com.typesafe.config.ConfigFactory
 
 object Studentify {
 
-  private val filesToCleanup = List(
-    ".git",
-    ".gitignore",
-    "man.sbt",
-    "navigation.sbt",
-    "shell-prompt.sbt",
-    "Jenkinsfile",
-    "Jenkinsfile.original",
-    "course-management.conf"
-  )
-
   def main(args: Array[String]): Unit = {
 
     import Helpers._
@@ -72,7 +61,7 @@ object Studentify {
     createBuildFile(targetCourseFolder, multiJVM)
     addSbtStudentCommands(sbtStudentCommandsTemplateFolder, targetCourseFolder)
     loadStudentSettings(masterRepo, targetCourseFolder)
-    cleanUp(filesToCleanup, targetCourseFolder)
+    cleanUp(config.studentifyFilesToCleanUp, targetCourseFolder)
     sbtio.delete(tmpDir)
 
   }

--- a/src/main/scala/com/lightbend/coursegentools/package.scala
+++ b/src/main/scala/com/lightbend/coursegentools/package.scala
@@ -24,16 +24,41 @@ import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Paths}
 
+import scala.util.matching.Regex
+
 package object coursegentools {
 
   def toConsoleRed(msg: String): String = Console.RED + msg + Console.RESET
+  def toConsoleGreen(msg: String): String = Console.GREEN + msg + Console.RESET
 
   type Seq[+A] = scala.collection.immutable.Seq[A]
   val Seq = scala.collection.immutable.Seq
 
+  val ExerciseNumberSpec: Regex = """exercise_(\d{3})_.*""".r
+
+  def extractExerciseNr(exercise: String): Int = {
+    val ExerciseNumberSpec(d) = exercise
+    d.toInt
+  }
+
+  def renumberExercise(exercise: String, newNumber: Int): String = {
+    val newNumerLZ = f"exercise_$newNumber%03d_"
+    val oldNumberPrefix = f"exercise_${extractExerciseNr(exercise)}%03d_"
+    exercise.replaceFirst(oldNumberPrefix, newNumerLZ)
+  }
+
+  def getExerciseName(exercises: Vector[String], exerciseNumber: Int): Option[String] = {
+    exercises.find(exercise => extractExerciseNr(exercise) == exerciseNumber)
+  }
+
   case class MasterAdmCmdOptions(masterRepo: File = new File("."),
                                  multiJVM: Boolean = false,
                                  regenBuildFile: Boolean = false,
+                                 duplicateExerciseInsertBeforeNr: Option[Int] = None,
+                                 deleteExerciseNr: Option[Int] = None,
+                                 renumberExercises: Boolean = false,
+                                 renumberExercisesBase: Int = 0,
+                                 renumberExercisesStep: Int = 1,
                                  configurationFile: Option[String] = None)
 
   case class StudentifyCmdOptions(masterRepo: File = new File("."),

--- a/src/main/scala/com/lightbend/coursegentools/package.scala
+++ b/src/main/scala/com/lightbend/coursegentools/package.scala
@@ -31,6 +31,11 @@ package object coursegentools {
   type Seq[+A] = scala.collection.immutable.Seq[A]
   val Seq = scala.collection.immutable.Seq
 
+  case class MasterAdmCmdOptions(masterRepo: File = new File("."),
+                                 multiJVM: Boolean = false,
+                                 regenBuildFile: Boolean = false,
+                                 configurationFile: Option[String] = None)
+
   case class StudentifyCmdOptions(masterRepo: File = new File("."),
                                   out: File = new File("."),
                                   multiJVM: Boolean = false,


### PR DESCRIPTION
 Add "masteradm" command with the following options:

- Re-generate the master project build file
- Configure name of master base project
- Delete an exercise
- Duplicate a given exercise and insert before that exercise
- Renumber all exercises
      - default is to start from 0 and increment by one
      - optionally specify an offset to start numbering
      - optionally specify "space" between consecutive
        exercises
- Move list of files to clean-up after "studentification" to config
- Update documentation