### PR TITLE
Fix swapping of command arguments in two places

### DIFF
--- a/src/main/scala/com/lightbend/coursegentools/DeLinearize.scala
+++ b/src/main/scala/com/lightbend/coursegentools/DeLinearize.scala
@@ -27,7 +27,7 @@ object DeLinearize {
 
     val cmdOptions = DeLinearizeCmdLineOptParse.parse(args)
     if (cmdOptions.isEmpty) System.exit(-1)
-    val DeLinearizeCmdOptions(linearizedRepo, masterRepo, optConfigurationFile) = cmdOptions.get
+    val DeLinearizeCmdOptions(masterRepo, linearizedRepo, optConfigurationFile) = cmdOptions.get
 
     implicit val config: MasterSettings = new MasterSettings(masterRepo, optConfigurationFile)
     implicit val eofe: ExitOnFirstError = ExitOnFirstError(true)

--- a/src/main/scala/com/lightbend/coursegentools/DeLinearizeCmdLineOptParse.scala
+++ b/src/main/scala/com/lightbend/coursegentools/DeLinearizeCmdLineOptParse.scala
@@ -31,20 +31,20 @@ object DeLinearizeCmdLineOptParse {
     val parser = new scopt.OptionParser[DeLinearizeCmdOptions]("delinearize") {
       head("delinearize", "3.0")
 
-      arg[File]("linearRepo")
-        .text("base folder for linearized version repo")
-        .action { case (linearRepo, config) =>
-          if (!folderExists(linearRepo))
-            printError(s"Base folder for linearized version repo (${linearRepo.getPath}) doesn't exist")
-          config.copy(linearRepo = linearRepo)
-        }
-
       arg[File]("masterRepo")
         .text("base folder holding master course repository")
         .action { case (masterRepo, c) =>
           if (!folderExists(masterRepo))
             printError(s"Base master repo folder (${masterRepo.getPath}) doesn't exist")
           c.copy(masterRepo = masterRepo)
+        }
+
+      arg[File]("linearRepo")
+        .text("linearized version repo")
+        .action { case (linearRepo, config) =>
+          if (!folderExists(linearRepo))
+            printError(s"Base folder for linearized version repo (${linearRepo.getPath}) doesn't exist")
+          config.copy(linearRepo = linearRepo)
         }
 
       opt[String]("config-file")


### PR DESCRIPTION
- Argument names & order were swapped, both in `scopt` def and in
  call to `delinearize` method. This caused the command to work
  when passing the masterRepo as the first argument and the
  folder holding the linearized repo as the second argument.
  Obviously, this was the opposite order of the one shown by
  `scopt` in the "Usage:" message which was very confusing.

In summary, the masterRepo is always the first argument in
both the `linearize` and the `delinearize` command