### PR TITLE
Make project prefix in master configurable

### DIFF
--- a/sbtMasterCommands/MPSelection.scala.template
+++ b/sbtMasterCommands/MPSelection.scala.template
@@ -12,8 +12,7 @@ import scala.util.matching.Regex
 
 object MPSelection {
 
-  val ExercisePathSpec: Regex = """(.*/exercise_)(\d{3})(_\w+)$""".r
-  val ExerciseNameSpec: Regex = """(exercise_)(\d{3})(_\w+)$""".r
+  val ExercisePathSpec: Regex = """(.*_)(\d{3})(_\w+)$""".r
 
   object FoldersOnly {
     def apply() = new FoldersOnly
@@ -42,7 +41,7 @@ object MPSelection {
   def activateExerciseNr(state: State, nr: Int): State = {
     val selectedProjectFolder = new sbt.File(Project.extract(state).structure.root)
     val exercises = getExerciseNames(selectedProjectFolder)
-    val activeExercisePrefix = f"exercise_$nr%03d.*"
+    val activeExercisePrefix = f".*_$nr%03d.*"
     val activeExercisePrefixSpec = activeExercisePrefix.r
     val activeExercise = exercises.find(exerciseName => activeExercisePrefixSpec.findFirstIn(exerciseName).isDefined)
     if (activeExercise.isEmpty) {

--- a/sbtMasterCommands/Navigation.scala.template
+++ b/sbtMasterCommands/Navigation.scala.template
@@ -21,7 +21,7 @@ object Navigation {
       .toList
       .map(r => r.project)
       // By convention, a project exercise has a 3-digit number in it enclosed in underscores
-      .filter(_.matches(""".*_[0-9][0-9][0-9]_.*"""))
+      .filter(_.matches(""".*_\d{3}_.*"""))
       .sorted
     if (refs.nonEmpty)
       Command.process(s"project ${refs.head}", state)

--- a/sbtMasterCommands/Navigation.scala.template
+++ b/sbtMasterCommands/Navigation.scala.template
@@ -5,6 +5,7 @@ package sbtstudent
   */
 
 import sbt._
+import scala.Console
 
 object Navigation {
 
@@ -19,8 +20,15 @@ object Navigation {
       .allProjectRefs
       .toList
       .map(r => r.project)
-      .filter(_.startsWith("exercise_"))
+      // By convention, a project exercise has a 3-digit number in it enclosed in underscores
+      .filter(_.matches(""".*_[0-9][0-9][0-9]_.*"""))
       .sorted
-    Command.process(s"project ${refs.head}", state)
+    if (refs.nonEmpty)
+      Command.process(s"project ${refs.head}", state)
+    else {
+      // No project was found adhering to the naming convention
+      println(s"\n${Console.RED}No projects found!${Console.RESET}\n")
+      state
+    }
   }
 }

--- a/sbtStudentCommands/Navigation.scala.template
+++ b/sbtStudentCommands/Navigation.scala.template
@@ -26,7 +26,7 @@ object Navigation {
     }
 
     val solF = new sbt.File(new sbt.File(Project.extract(state).structure.root), ".cue")
-    val ExerciseNameSpec = """.*_[0-9][0-9][0-9]_\w+\.zip$""".r
+    val ExerciseNameSpec = """.*_\d{3}_\w+\.zip$""".r
 
     def isExerciseFolder(folder: File): Boolean = {
       ExerciseNameSpec.findFirstIn(folder.getPath).isDefined
@@ -86,7 +86,7 @@ object Navigation {
 
   def listExercises: Command = Command.command("listExercises") { state =>
     val ExFmt =
-      s""".*_([0-9]+)_(.*)""".r
+      s""".*_(\d+)_(.*)""".r
     val exList = mapExercises(state).toList.map(_._1).sorted.zipWithIndex
         .foreach { case (exName, seq) =>
           val ExFmt(exNr, exDesc)= exName

--- a/sbtStudentCommands/Navigation.scala.template
+++ b/sbtStudentCommands/Navigation.scala.template
@@ -26,7 +26,7 @@ object Navigation {
     }
 
     val solF = new sbt.File(new sbt.File(Project.extract(state).structure.root), ".cue")
-    val ExerciseNameSpec = """.*exercise_[0-9][0-9][0-9]_\w+\.zip$""".r
+    val ExerciseNameSpec = """.*_[0-9][0-9][0-9]_\w+\.zip$""".r
 
     def isExerciseFolder(folder: File): Boolean = {
       ExerciseNameSpec.findFirstIn(folder.getPath).isDefined
@@ -86,7 +86,7 @@ object Navigation {
 
   def listExercises: Command = Command.command("listExercises") { state =>
     val ExFmt =
-      s"""exercise_([0-9]+)_(.*)""".r
+      s""".*_([0-9]+)_(.*)""".r
     val exList = mapExercises(state).toList.map(_._1).sorted.zipWithIndex
         .foreach { case (exName, seq) =>
           val ExFmt(exNr, exDesc)= exName

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -7,6 +7,12 @@ studentify {
     "src/test"
   ]
 
+  # Prefix of the project names in the master repo. As this tooling was
+  # created for managing training materials, the prefix was "exercise"
+  # This new settings allows for setting to something more meaningful
+  # in the context of its application (like "step", "demo_step", ...)
+  exercise-project-prefix = exercise
+
   # Studentify mode
   studentify-mode-select = classic
 

--- a/src/main/scala/com/lightbend/coursegentools/Helpers.scala
+++ b/src/main/scala/com/lightbend/coursegentools/Helpers.scala
@@ -29,8 +29,6 @@ object Helpers {
 
   import ProcessDSL._
 
-  val ExerciseNameSpec = """.*[/\\\\]exercise_[0-9][0-9][0-9]_\w+$""".r
-
   def fileList(base: File): Vector[File] = {
     @scala.annotation.tailrec
     def fileList(filesSoFar: Vector[File], folders: Vector[File]): Vector[File] = {
@@ -53,6 +51,11 @@ object Helpers {
     val zipFile = new File(exFolder.getParentFile, s"${exFolder.getName}.zip")
     sbtio.zip(fl, zipFile)
     if (removeOriginal) sbtio.delete(exFolder)
+  }
+
+  def cleanDestinationFolder(targetCourseFolder: File): Unit = {
+    val fl = fileList(targetCourseFolder).map(f => (f, sbtio.relativize(targetCourseFolder.getParentFile, f).get))
+    println(fl.mkString("\n"))
   }
 
   def addMasterCommands(masterRepo: File)(implicit config: MasterSettings, exitOnFirstError: ExitOnFirstError): Unit = {
@@ -248,7 +251,10 @@ object Helpers {
     tmpDir
   }
 
-  def isExerciseFolder(folder: File): Boolean = {
+  def isExerciseFolder(folder: File)(implicit config: MasterSettings): Boolean = {
+
+    val ExerciseNameSpec = s""".*[/\\\\]${config.exerciseProjectPrefix}_[0-9][0-9][0-9]_\\w+$$""".r
+
     ExerciseNameSpec.findFirstIn(folder.getPath).isDefined
   }
 
@@ -336,7 +342,7 @@ object Helpers {
                         exerciseNr: Int)(implicit config: MasterSettings): Unit = {
 
     val relativeSourceFolder = new File(masterRepo, config.relativeSourceFolder)
-    val newExercise = renumberExercise(exercise, exerciseNr) + "_copy"
+    val newExercise =   renumberExercise(exercise, exerciseNr) + "_copy"
     sbtio.copyDirectory(new File(relativeSourceFolder, exercise), new File(relativeSourceFolder, newExercise), preserveLastModified = true)
   }
 

--- a/src/main/scala/com/lightbend/coursegentools/Helpers.scala
+++ b/src/main/scala/com/lightbend/coursegentools/Helpers.scala
@@ -253,7 +253,7 @@ object Helpers {
 
   def isExerciseFolder(folder: File)(implicit config: MasterSettings): Boolean = {
 
-    val ExerciseNameSpec = s""".*[/\\\\]${config.exerciseProjectPrefix}_[0-9][0-9][0-9]_\\w+$$""".r
+    val ExerciseNameSpec = s""".*[/\\\\]${config.exerciseProjectPrefix}_\\d{3}_\\w+$$""".r
 
     ExerciseNameSpec.findFirstIn(folder.getPath).isDefined
   }

--- a/src/main/scala/com/lightbend/coursegentools/MasterSettings.scala
+++ b/src/main/scala/com/lightbend/coursegentools/MasterSettings.scala
@@ -55,6 +55,8 @@ class MasterSettings(masterRepo: File, optConfigurationFile: Option[String]) {
 
   val testCodeFolders: List[String] = config.getStringList("studentify.test-code-folders").asScala.toList
 
+  val exerciseProjectPrefix: String = config.getString("studentify.exercise-project-prefix")
+
   val studentifyModeSelect: String = config.getString("studentify.studentify-mode-select")
 
   val studentifyFilesToCleanUp: List[String] = config.getStringList("studentify.studentify-files-to-clean-up").asScala.toList

--- a/src/main/scala/com/lightbend/coursegentools/Studentify.scala
+++ b/src/main/scala/com/lightbend/coursegentools/Studentify.scala
@@ -44,6 +44,7 @@ object Studentify {
     val cleanMasterRepo = new File(tmpDir, projectName)
 
     implicit val config: MasterSettings = new MasterSettings(masterRepo, configurationFile)
+
     import config.testCodeFolders, config.studentifyModeClassic.studentifiedBaseFolder
 
     val exercises: Seq[String] = getExerciseNames(cleanMasterRepo, Some(masterRepo))

--- a/src/main/scala/com/lightbend/coursegentools/package.scala
+++ b/src/main/scala/com/lightbend/coursegentools/package.scala
@@ -43,16 +43,16 @@ package object coursegentools {
   type Seq[+A] = scala.collection.immutable.Seq[A]
   val Seq = scala.collection.immutable.Seq
 
-  val ExerciseNumberSpec: Regex = """exercise_(\d{3})_.*""".r
+  val ExerciseNumberSpec: Regex = """.*_(\d{3})_.*""".r
 
   def extractExerciseNr(exercise: String): Int = {
     val ExerciseNumberSpec(d) = exercise
     d.toInt
   }
 
-  def renumberExercise(exercise: String, newNumber: Int): String = {
-    val newNumerLZ = f"exercise_$newNumber%03d_"
-    val oldNumberPrefix = f"exercise_${extractExerciseNr(exercise)}%03d_"
+  def renumberExercise(exercise: String, newNumber: Int)(implicit config: MasterSettings): String = {
+    val newNumerLZ = f"${config.exerciseProjectPrefix}_$newNumber%03d_"
+    val oldNumberPrefix = f"${config.exerciseProjectPrefix}_${extractExerciseNr(exercise)}%03d_"
     exercise.replaceFirst(oldNumberPrefix, newNumerLZ)
   }
 


### PR DESCRIPTION
Until now, the different exercises in the master project had to have a name prefixed by the fixed string _exercise_.
This is now configurable via the `studentify.exercise-project-prefix` setting.
Add this setting to set the prefix to the one you use in the master project