### PR TITLE
Make prompt in master repo and studentified version consistent

### DIFF
--- a/sbtMasterCommands/StudentCommandsPlugin.scala.template
+++ b/sbtMasterCommands/StudentCommandsPlugin.scala.template
@@ -1,7 +1,7 @@
 package sbtstudent
 
 import sbt.Keys._
-import sbt._
+import sbt.{Def, _}
 import stbstudent.MPSelection
 
 import scala.Console
@@ -24,14 +24,24 @@ object StudentCommandsPlugin extends AutoPlugin {
       }
     )
 
-  override lazy val projectSettings =
+  def extractCurrentExerciseDesc(state: State): String = {
+    val currentExercise =  Project.extract(state).currentProject.id
+
+    currentExercise
+      .replaceFirst("""^.*_\d{3}_""", "")
+      .replaceAll("_", " ")
+  }
+
+  def extractProjectName(state: State): String = {
+    IO.readLines(new sbt.File(new sbt.File(Project.extract(state).structure.root), ".courseName")).head
+  }
+
+  override lazy val projectSettings: Seq[Def.Setting[State => String]] =
     Seq(
       shellPrompt := { state =>
-        val base: File = Project.extract(state).get(sourceDirectory)
-        val basePath: String = base + "/test/resources/README.md"
-        val exercise = Console.GREEN + IO.readLines(new sbt.File(basePath)).head + Console.RESET
+        val exercise = Console.GREEN + extractCurrentExerciseDesc(state) + Console.RESET
         val manRmnd = Console.GREEN + "man [e]" + Console.RESET
-        val prjNbrNme = IO.readLines(new sbt.File(new sbt.File(Project.extract(state).structure.root), ".courseName")).head
+        val prjNbrNme = extractProjectName(state)
         s"$manRmnd > $prjNbrNme > $exercise > "
       }
     )

--- a/sbtStudentCommands/Navigation.scala.template
+++ b/sbtStudentCommands/Navigation.scala.template
@@ -85,14 +85,10 @@ object Navigation {
   }
 
   def listExercises: Command = Command.command("listExercises") { state =>
-    val ExFmt =
-      s""".*_(\d+)_(.*)""".r
-    val exList = mapExercises(state).toList.map(_._1).sorted.zipWithIndex
-        .foreach { case (exName, seq) =>
-          val ExFmt(exNr, exDesc)= exName
-          val ed = f"Exercise ${exNr.toInt}%d > ${exDesc.split("_").map(s => s"${s.head.toUpper}${s.tail}").mkString(" ")}"
-          Console.println(Console.RED + s"${seq.toInt}. " + Console.RESET + s"$ed")
-        }
+    mapExercises(state).toList.map(_._1).sorted.zipWithIndex
+      .foreach { case (exName, seq) =>
+        Console.println(Console.GREEN + f"${seq.toInt + 1}%3d. " + Console.RESET + s"$exName")
+      }
     state
   }
 

--- a/sbtStudentCommands/StudentCommandsPlugin.scala.template
+++ b/sbtStudentCommands/StudentCommandsPlugin.scala.template
@@ -5,7 +5,7 @@ package sbtstudent
  */
 
 import sbt.Keys._
-import sbt._
+import sbt.{Def, _}
 
 import scala.Console
 
@@ -30,17 +30,28 @@ object StudentCommandsPlugin extends AutoPlugin {
       }
     )
 
-  override lazy val projectSettings =
+  def extractCurrentExerciseDesc(state: State): String = {
+    val currentExercise = IO.readLines(new sbt.File(new sbt.File(Project.extract(state).structure.root), ".bookmark")).head
+
+    currentExercise
+      .replaceFirst("""^.*_\d{3}_""", "")
+      .replaceAll("_", " ")
+  }
+
+  def extractProjectName(state: State): String = {
+    IO.readLines(new sbt.File(new sbt.File(Project.extract(state).structure.root), ".courseName")).head
+  }
+
+  override lazy val projectSettings: Seq[Def.Setting[State => String]] =
     Seq(
       shellPrompt := { state =>
         val promptCourseNameColor = SSettings.consoleColorMap(SSettings.promptCourseNameColor)
         val promptExerciseColor = SSettings.consoleColorMap(SSettings.promptExerciseColor)
         val promptManColor = SSettings.consoleColorMap(SSettings.promptManColor)
-        val base: File = Project.extract(state).get(sourceDirectory)
-        val basePath: String = base + "/test/resources/README.md"
-        val exercise = promptExerciseColor + IO.readLines(new sbt.File(basePath)).head + Console.RESET
+        val exercise = promptExerciseColor + extractCurrentExerciseDesc(state) + Console.RESET
         val manRmnd = promptManColor + "man [e]" + Console.RESET
-        val prjNbrNme = promptCourseNameColor + IO.readLines(new sbt.File(new sbt.File(Project.extract(state).structure.root), ".courseName")).head + Console.RESET
+        val prjNbrNme = promptCourseNameColor + extractProjectName(state) + Console.RESET
+
         s"$manRmnd > $prjNbrNme > $exercise > "
       }
     )


### PR DESCRIPTION
- The exercise description in the sbt prompt is now generated from
  the project name corresponding to the exercise. The prefix and
  exercise number is deleted and the remainder is copied in the
  prompt whereby underscores are replaced with spaces. Also,
  capitalisation is preserved.
- Breaking change: the convention to extract the exercise description
  is no longer followed. Hence this line, if present in projects
  can be removed.
- The 'listExercises' command's output has been changed to show
  the full exercise project name. This is more useful than the
  reformatted string that couldn't really be linked to the
  project name.