### PR TITLE
Add support for alternate location of README file in exercises

### DIFF
--- a/sbtMasterCommands/Man.scala.template
+++ b/sbtMasterCommands/Man.scala.template
@@ -20,8 +20,11 @@ object Man {
     arg match {
       case Some(a) if a == "e" =>
         val base: File = Project.extract(state).get(sourceDirectory)
-        val basePath: String = base + "/test/resources/README.md"
-        printOut(basePath)
+        val readmeFile: File = {
+          val bPath = new File(base, "/test/resources/README.md")
+          if (bPath.isFile) bPath else new File(base, "../README.md")
+        }
+        printOut(readmeFile)
         Console.print("\n")
         state
       case Some(a) =>
@@ -32,8 +35,7 @@ object Man {
       case None =>
         val base: File = Project.extract(state).get(baseDirectory)
         val readMeFile = new sbt.File(new sbt.File(Project.extract(state).structure.root), "README.md")
-        val basePath = readMeFile.getPath
-        printOut(basePath)
+        printOut(readMeFile)
         Console.print("\n")
         state
     }
@@ -53,9 +55,9 @@ object Man {
   val ConReset = Console.RESET
   val ConYellow = Console.YELLOW
 
-  def printOut(path: String) {
+  def printOut(path: File) {
     var inCodeFence = false
-    IO.readLines(new sbt.File(path)) foreach {
+    IO.readLines(path) foreach {
       case ln if !inCodeFence && ln.length > 0 && ln(0).equals('#') =>
         Console.println(ConRed + ln + ConReset)
       case ln if !inCodeFence && ln.matches(".*" + bulletRx.toString() + ".*") =>

--- a/sbtStudentCommands/Man.scala.template
+++ b/sbtStudentCommands/Man.scala.template
@@ -18,9 +18,12 @@ object Man {
   def man: Command = Command("man")(_ => optArg) { (state, arg) =>
     arg match {
       case Some(a) if a == "e" =>
-        val base: File = Project.extract(state).get(sourceDirectory)
-        val basePath: String = base + "/test/resources/README.md"
-        printOut(basePath)
+        val readmeFile: File =
+          if (SSettings.readmeFilesInExerciseRootFolder)
+            new File(new File(Project.extract(state).structure.root.getPath, SSettings.studentifiedBaseFolder), "README.md")
+          else
+            new File(Project.extract(state).get(sourceDirectory), "test/resources/README.md")
+        printOut(readmeFile)
         Console.print("\n")
         state
       case Some(a) =>
@@ -31,8 +34,7 @@ object Man {
       case None =>
         val base: File = Project.extract(state).get(baseDirectory)
         val readMeFile = new sbt.File(new sbt.File(Project.extract(state).structure.root), "README.md")
-        val basePath = readMeFile.getPath
-        printOut(basePath)
+        printOut(readMeFile)
         Console.print("\n")
         state
     }
@@ -52,9 +54,9 @@ object Man {
   val ConReset = Console.RESET
   val ConYellow = Console.YELLOW
 
-  def printOut(path: String) {
+  def printOut(path: File) {
     var inCodeFence = false
-    IO.readLines(new sbt.File(path)) foreach {
+    IO.readLines(path) foreach {
       case ln if !inCodeFence && ln.length > 0 && ln(0).equals('#') =>
         Console.println(ConRed + ln + ConReset)
       case ln if !inCodeFence && ln.matches(".*" + bulletRx.toString() + ".*") =>

--- a/sbtStudentCommands/Man.scala.template
+++ b/sbtStudentCommands/Man.scala.template
@@ -19,10 +19,10 @@ object Man {
     arg match {
       case Some(a) if a == "e" =>
         val readmeFile: File =
-          if (SSettings.readmeFilesInExerciseRootFolder)
-            new File(new File(Project.extract(state).structure.root.getPath, SSettings.studentifiedBaseFolder), "README.md")
-          else
+          if (SSettings.readmeInTestResources)
             new File(Project.extract(state).get(sourceDirectory), "test/resources/README.md")
+          else
+            new File(new File(Project.extract(state).structure.root.getPath, SSettings.studentifiedBaseFolder), "README.md")
         printOut(readmeFile)
         Console.print("\n")
         state

--- a/sbtStudentCommands/Navigation.scala.template
+++ b/sbtStudentCommands/Navigation.scala.template
@@ -84,16 +84,21 @@ object Navigation {
     newState
   }
 
+  def starCurrentExercise(currentExercise: String, exercise: String): String = {
+    if (currentExercise == exercise) " * " else "   "
+  }
+
   def listExercises: Command = Command.command("listExercises") { state =>
+    val currentExercise = getExerciseName(state)
     mapExercises(state).toList.map(_._1).sorted.zipWithIndex
       .foreach { case (exName, seq) =>
-        Console.println(Console.GREEN + f"${seq.toInt + 1}%3d. " + Console.RESET + s"$exName")
+        Console.println(Console.GREEN + f"${seq.toInt + 1}%3d." + starCurrentExercise(currentExercise, exName) + Console.RESET + s"$exName")
       }
     state
   }
 
   def copyExerciseReadme(newExerciseSrc: sbt.File, src: sbt.File): Unit = {
-    if (SSettings.readmeFilesInExerciseRootFolder)
+    if (! SSettings.readmeInTestResources)
       IO.copyFile(new File(newExerciseSrc, "README.md"), new File(src, "README.md"))
   }
 
@@ -144,7 +149,7 @@ object Navigation {
   }
 
   def gotoExerciseNr: Command = Command("gotoExerciseNr")(s => ExerciseNr) { (state, arg) =>
-    val ExerciseFmt = """.*_([0-9][0-9][0-9])_\w+$""".r
+    val ExerciseFmt = """.*_(\d{3})_\w+$""".r
     arg match {
       case Some(exerciseNr) =>
         val exercises =
@@ -214,7 +219,6 @@ object Navigation {
           val src = new sbt.File(new sbt.File(Project.extract(state).structure.root), SSettings.studentifiedBaseFolder)
           val newExerciseSrc = new sbt.File(new sbt.File(Project.extract(state).structure.root), s".cue/$toProjectName")
           copyExerciseReadme(newExerciseSrc, src)
-          println(s"~~> newExerciseSrc = ${newExerciseSrc} - src = $src")
           for {
             f <- SSettings.testFolders
             fromFolder = new File(newExerciseSrc, f)

--- a/sbtStudentCommands/Navigation.scala.template
+++ b/sbtStudentCommands/Navigation.scala.template
@@ -50,7 +50,7 @@ object Navigation {
     s.put(allExercises, Space ~ Parser.oneOf(ex))
   }
 
-  val setupNavAttrs: (State) => State = (s: State) => {
+  val setupNavAttrs: State => State = (s: State) => {
 
     val mark: File = s get bookmark getOrElse new sbt.File(new sbt.File(Project.extract(s).structure.root), ".bookmark")
     val prev: Map[String, String] = s get mapPrev getOrElse mapExercises(s, reverse = true)
@@ -92,6 +92,11 @@ object Navigation {
     state
   }
 
+  def copyExerciseReadme(newExerciseSrc: sbt.File, src: sbt.File): Unit = {
+    if (SSettings.readmeFilesInExerciseRootFolder)
+      IO.copyFile(new File(newExerciseSrc, "README.md"), new File(src, "README.md"))
+  }
+
   private lazy val ExerciseNr = Space ~> IntBasic.?
 
   def gotoFirstExercise: Command = Command.command("gotoFirstExercise") { state =>
@@ -99,6 +104,7 @@ object Navigation {
     withZipFile(state, firstExercise) { () =>
       val src = new sbt.File(new sbt.File(Project.extract(state).structure.root), SSettings.studentifiedBaseFolder)
       val newExerciseSrc = new sbt.File(new sbt.File(Project.extract(state).structure.root), s".cue/$firstExercise")
+      copyExerciseReadme(newExerciseSrc, src)
       for {
         f <- SSettings.testFolders
         fromFolder = new File(newExerciseSrc, f)
@@ -121,6 +127,7 @@ object Navigation {
     withZipFile(state, exercise) { () =>
       val src = new sbt.File(new sbt.File(Project.extract(state).structure.root), SSettings.studentifiedBaseFolder)
       val newExerciseSrc = new sbt.File(new sbt.File(Project.extract(state).structure.root), s".cue/$exercise")
+      copyExerciseReadme(newExerciseSrc, src)
       for {
         f <- SSettings.testFolders
         fromFolder = new File(newExerciseSrc, f)
@@ -137,7 +144,7 @@ object Navigation {
   }
 
   def gotoExerciseNr: Command = Command("gotoExerciseNr")(s => ExerciseNr) { (state, arg) =>
-    val ExerciseFmt = """.*exercise_([0-9][0-9][0-9])_\w+$""".r
+    val ExerciseFmt = """.*_([0-9][0-9][0-9])_\w+$""".r
     arg match {
       case Some(exerciseNr) =>
         val exercises =
@@ -154,6 +161,7 @@ object Navigation {
             withZipFile(state, exercise) { () =>
               val src = new sbt.File(new sbt.File(Project.extract(state).structure.root), SSettings.studentifiedBaseFolder)
               val newExerciseSrc = new sbt.File(new sbt.File(Project.extract(state).structure.root), s".cue/$exercise")
+              copyExerciseReadme(newExerciseSrc, src)
               for {
                 f <- SSettings.testFolders
                 fromFolder = new File(newExerciseSrc, f)
@@ -205,6 +213,8 @@ object Navigation {
         withZipFile(state, toProjectName) { () =>
           val src = new sbt.File(new sbt.File(Project.extract(state).structure.root), SSettings.studentifiedBaseFolder)
           val newExerciseSrc = new sbt.File(new sbt.File(Project.extract(state).structure.root), s".cue/$toProjectName")
+          copyExerciseReadme(newExerciseSrc, src)
+          println(s"~~> newExerciseSrc = ${newExerciseSrc} - src = $src")
           for {
             f <- SSettings.testFolders
             fromFolder = new File(newExerciseSrc, f)

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -22,9 +22,10 @@ studentify {
     studentified-base-folder = exercises
   }
 
-  # Exercise README.md files in the exercise project folder's root
-  readme-files-in-exercise-root-folder = false
-
+  # Exercise README.md files in the exercise project test resources folder
+  # If this setting is set false, the README.md should be in the exercise
+  # project root folder
+  readme-in-test-resources = true
 
   # Use 'configure' instead of 'settings' to add per-project configuration
   use-configure-for-projects = false

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -22,6 +22,10 @@ studentify {
     studentified-base-folder = exercises
   }
 
+  # Exercise README.md files in the exercise project folder's root
+  readme-files-in-exercise-root-folder = false
+
+
   # Use 'configure' instead of 'settings' to add per-project configuration
   use-configure-for-projects = false
 

--- a/src/main/scala/com/lightbend/coursegentools/Helpers.scala
+++ b/src/main/scala/com/lightbend/coursegentools/Helpers.scala
@@ -512,6 +512,8 @@ object Helpers {
          |
          |  val studentifiedBaseFolder = "${masterSettings.studentifyModeClassic.studentifiedBaseFolder}"
          |
+         |  val readmeFilesInExerciseRootFolder: Boolean = ${masterSettings.readmeFilesInExerciseRootFolder}
+         |
          |  val promptManColor         = "${masterSettings.Colors.promptManColor}"
          |  val promptExerciseColor    = "${masterSettings.Colors.promptExerciseColor}"
          |  val promptCourseNameColor = "${masterSettings.Colors.promptCourseNameColor}"

--- a/src/main/scala/com/lightbend/coursegentools/Helpers.scala
+++ b/src/main/scala/com/lightbend/coursegentools/Helpers.scala
@@ -512,7 +512,7 @@ object Helpers {
          |
          |  val studentifiedBaseFolder = "${masterSettings.studentifyModeClassic.studentifiedBaseFolder}"
          |
-         |  val readmeFilesInExerciseRootFolder: Boolean = ${masterSettings.readmeFilesInExerciseRootFolder}
+         |  val readmeInTestResources: Boolean = ${masterSettings.readmeInTestResources}
          |
          |  val promptManColor         = "${masterSettings.Colors.promptManColor}"
          |  val promptExerciseColor    = "${masterSettings.Colors.promptExerciseColor}"

--- a/src/main/scala/com/lightbend/coursegentools/MasterSettings.scala
+++ b/src/main/scala/com/lightbend/coursegentools/MasterSettings.scala
@@ -63,6 +63,8 @@ class MasterSettings(masterRepo: File, optConfigurationFile: Option[String]) {
 
   val relativeSourceFolder: String = config.getString("studentify.relative-source-folder")
 
+  val readmeFilesInExerciseRootFolder: Boolean = config.getBoolean("studentify.readme-files-in-exercise-root-folder")
+
   val useConfigureForProjects: Boolean = config.getBoolean("studentify.use-configure-for-projects")
 
   object studentifyModeClassic {

--- a/src/main/scala/com/lightbend/coursegentools/MasterSettings.scala
+++ b/src/main/scala/com/lightbend/coursegentools/MasterSettings.scala
@@ -63,7 +63,7 @@ class MasterSettings(masterRepo: File, optConfigurationFile: Option[String]) {
 
   val relativeSourceFolder: String = config.getString("studentify.relative-source-folder")
 
-  val readmeFilesInExerciseRootFolder: Boolean = config.getBoolean("studentify.readme-files-in-exercise-root-folder")
+  val readmeInTestResources: Boolean = config.getBoolean("studentify.readme-in-test-resources")
 
   val useConfigureForProjects: Boolean = config.getBoolean("studentify.use-configure-for-projects")
 


### PR DESCRIPTION
Apart from the default location of the README.md files in
`project/src/test/resources/README.md`, an alternate location can be
selected by setting `studentify.readme-files-in-exercise-root-folder`
to `true` in configuration