### PR TITLE
Add test script generation option to masteradm

### DIFF
--- a/sbtStudentCommands/Pssr.scala.template
+++ b/sbtStudentCommands/Pssr.scala.template
@@ -83,7 +83,7 @@ object Pssr {
 
   def savedStates: Command = Command.command("savedStates") { state =>
     val savedState = getSavedStateFolder(state)
-    val savedExercises = IO.listFiles(savedState).map(_.getName).toList
+    val savedExercises = IO.listFiles(savedState).map(_.getName).toList.sorted
     if (savedExercises.isEmpty) {
       Console.println(Console.YELLOW + "[WARN] " + Console.RESET + s"No previously saved exercise states found")
     } else {

--- a/src/main/scala/com/lightbend/coursegentools/GenTests.scala
+++ b/src/main/scala/com/lightbend/coursegentools/GenTests.scala
@@ -19,7 +19,7 @@ object GenTests {
     val configurationFileArgument = if(configurationFile.isDefined) s"-cfg ${configurationFile.get}" else ""
 
     val script: String =
-      s"""#!/bin/bash
+      s"""#!/bin/bash -e -o pipefail
         |
         |CMT_FOLDER=$cmtFolder # This should become a script argument at some stage
         |

--- a/src/main/scala/com/lightbend/coursegentools/GenTests.scala
+++ b/src/main/scala/com/lightbend/coursegentools/GenTests.scala
@@ -1,0 +1,77 @@
+package com.lightbend.coursegentools
+
+import java.io.File
+
+import scala.util.Random
+
+object GenTests {
+  def generateTestScript(masterRepo: File,
+                         relativeSourceFolder: String,
+                         configurationFile: Option[String],
+                         testScript: File,
+                         exercises: Vector[String],
+                         exerciseNumbers: Vector[Int]): Unit = {
+    val masterRepoPath = masterRepo.getAbsolutePath
+    val exerciseFolderPath: String =
+      if (relativeSourceFolder != "") new File(masterRepo, relativeSourceFolder).getAbsolutePath else masterRepoPath
+
+    val cmtFolder = System.getProperty("user.dir")
+    val configurationFileArgument = if(configurationFile.isDefined) s"-cfg ${configurationFile.get}" else ""
+
+    val script: String =
+      s"""#!/bin/bash
+        |
+        |CMT_FOLDER=$cmtFolder # This should become a script argument at some stage
+        |
+        |${separator("Test master repo 'man e', 'test'")}
+        |cd $exerciseFolderPath
+        |sbt "${genMasterExerciseTestCmds(exercises)}"
+        |
+        |${separator("Create a temporary folder to hold studentified version")}
+        |TMP_DIR=$$(mktemp -d /tmp/CMT.XXXXXX)
+        |cd $$CMT_FOLDER
+        |
+        |${separator("Studentify the project")}
+        |sbt "studentify $configurationFileArgument $masterRepoPath $$TMP_DIR"
+        |
+        |${separator("Test studentified project:\n  Exercise 'nextExercise', 'pullSolution', 'listExercises', 'man e' commands")}
+        |cd $$TMP_DIR/${masterRepo.getName}
+        |sbt "${genStudentifiedTestCmds(exercises)}"
+        |
+        |${separator("Test studentified project:\n  Exercise 'gotoExercise', 'gotoExerciseNr', 'pullSolution', 'test', 'listExercises'")}
+        |sbt "${genGotoExerciseTestCmds(exercises, exerciseNumbers)}"
+        |
+        |# Clean up after ourselves
+        |trap "rm -rf $$TMP_DIR" 0
+      """.stripMargin
+
+    dumpStringToFile(script, testScript.getAbsolutePath)
+
+  }
+
+  def separator(message: String): String = {
+    s"""echo "
+       |==========================================================
+       |$message
+       |==========================================================
+       |"
+     """.stripMargin
+  }
+
+  def genMasterExerciseTestCmds(exercises: Vector[String]): String = {
+    exercises.map(exercise => s";project $exercise;compile;test;man e").mkString("\n", "\n", "")
+  }
+
+  def genStudentifiedTestCmds(exercises: Vector[String]): String = {
+    exercises.map(_ => ";listExercises;pullSolution;man e;compile;test;nextExercise").mkString("\n", "\n", "") +
+      ";gotoFirstExercise;listExercises"
+  }
+
+  def genGotoExerciseTestCmds(exercises: Vector[String], exerciseNumbers: Vector[Int]): String = {
+    Random.shuffle(exercises).zip(Random.shuffle(exerciseNumbers))
+      .map{ case (exercise, exerciseNumber) =>
+        s""";gotoExercise $exercise; pullSolution; listExercises; test; prevExercise
+           |;gotoExerciseNr $exerciseNumber; pullSolution; listExercises; test; man e; prevExercise""".stripMargin}
+      .mkString("\n", "\n", "")
+  }
+}

--- a/src/main/scala/com/lightbend/coursegentools/GenTests.scala
+++ b/src/main/scala/com/lightbend/coursegentools/GenTests.scala
@@ -38,7 +38,7 @@ object GenTests {
         |cd $$TMP_DIR/${masterRepo.getName}
         |sbt "${genStudentifiedTestCmds(exercises)}"
         |
-        |${separator("Test studentified project:\n  Exercise 'gotoExercise', 'gotoExerciseNr', 'pullSolution', 'test', 'listExercises'")}
+        |${separator("Test studentified project:\n  Exercise 'gotoExercise', 'gotoExerciseNr', 'pullSolution', 'test', 'listExercises, 'saveState', savedStates', 'restoreState''")}
         |sbt "${genGotoExerciseTestCmds(exercises, exerciseNumbers)}"
         |
         |# Clean up after ourselves
@@ -70,8 +70,8 @@ object GenTests {
   def genGotoExerciseTestCmds(exercises: Vector[String], exerciseNumbers: Vector[Int]): String = {
     Random.shuffle(exercises).zip(Random.shuffle(exerciseNumbers))
       .map{ case (exercise, exerciseNumber) =>
-        s""";gotoExercise $exercise; pullSolution; listExercises; test; prevExercise
-           |;gotoExerciseNr $exerciseNumber; pullSolution; listExercises; test; man e; prevExercise""".stripMargin}
+        s""";gotoExercise $exercise; pullSolution; saveState; savedStates; listExercises; test; prevExercise
+           |;gotoExerciseNr $exerciseNumber; pullSolution; listExercises; test; man e; prevExercise; restoreState $exercise""".stripMargin}
       .mkString("\n", "\n", "")
   }
 }

--- a/src/main/scala/com/lightbend/coursegentools/MasterAdmCmdLineOptParse.scala
+++ b/src/main/scala/com/lightbend/coursegentools/MasterAdmCmdLineOptParse.scala
@@ -110,6 +110,14 @@ object MasterAdmCmdLineOptParse {
             case (_, c) =>
               c.copy(addMasterCommands = true)
           }
+
+      opt[File]("generate-tests-script")
+        .text("generate a script that tests master repo, studentified repo functionality and linearize/delinearize")
+        .abbr("t")
+        .action {
+          case (testFile, c) =>
+            c.copy(testFile = Some(testFile))
+        }
     }
 
     parser.parse(args, MasterAdmCmdOptions())

--- a/src/main/scala/com/lightbend/coursegentools/package.scala
+++ b/src/main/scala/com/lightbend/coursegentools/package.scala
@@ -73,7 +73,8 @@ package object coursegentools {
                                  configurationFile: Option[String] = None,
                                  checkMaster: Boolean = false,
                                  addMasterCommands: Boolean = false,
-                                 useConfigureForProjects: Boolean = false)
+                                 useConfigureForProjects: Boolean = false,
+                                 testFile: Option[File] = None)
 
   case class StudentifyCmdOptions(masterRepo: File = new File("."),
                                   out: File = new File("."),


### PR DESCRIPTION
- This new option will generate a test script for a given master
  repository that exercises various commands linked to the
  Course Management Tools:
  - On the master repo:
    - `man e` on each project step.
    - `sbt compile/test` on each project step.
  - On a studentified version of the repo:
    - `man e' on each project step.
    - `listExercises`.
    - `nextExercise`, `prevExercise`, `pullSolution`.
    - `sbt compile/test` on each project step.
    - `gotoExercise` and `gotoExerciseNr`
    - `gotoFirstExercise`
    - `saveState`, `restoreState` and `savedStates`
- Unrelated: changes 'savedStates' to give a sorted list of saved states

- This new feature will be used to test the proper functioning of
  master repositories (note, of course, that the proper functioning
  of the contained exercise code is a responsibility of the project
  author(s)).
- Using Travis, this testing can be automated.
- Using a number of reference projects, to be added to the Course
  Management Tools _(CMT)_ project, regression testing can be implemented.

TODO:

- Add a few reference project and set-up _Travis_ on _CMT_ repo to enable
  automated verification of regressions on _CMT_ updates.
- Add testing of _CMT's_ `linearize` and `delinearize` commands.