### PR TITLE
Make cpCleanViaGit more robust

### DIFF
--- a/cpCleanViaGit.sh
+++ b/cpCleanViaGit.sh
@@ -10,14 +10,17 @@ cd $MASTER
 MASTER=`pwd`
 CUR_BRANCH=`git branch | sed -e '/^ /d' -e 's/^..//'`
 
+TMP_REMOTE=CMT-`uuidgen|tr '[:upper:]' '[:lower:]'`
+
 cd $TMP_DIR                               &&
 mkdir ${REMOTE_REPO}                      &&
 git init --bare $REMOTE_REPO              &&
 cd $REMOTE_REPO                           &&
 REPO=`pwd`                                &&
 cd $MASTER                                &&
-git remote add tmpRepo $REPO              &&
-git push tmpRepo $CUR_BRANCH              &&
-git remote remove tmpRepo                 &&
+git remote add $TMP_REMOTE $REPO          &&
+git push $TMP_REMOTE $CUR_BRANCH          &&
 cd $TMP_DIR                               &&
 git clone -b $CUR_BRANCH $REPO
+
+trap "cd $MASTER; git remote remove $TMP_REMOTE" 0


### PR DESCRIPTION
Using a static name for the temporary remote on the master git repo is
not very robust. In case the cleanup is not performed (for example
in case the execution of 'studentify' or 'linearize' is interrupted
by the user), subsequent runs of 'studentify' or 'linearize' will
fail systematically. With this change, the added remote gets a random
name (UUID) prefixed by the string 'CMT-'.